### PR TITLE
feat: use projectile instead of find-file-in-project

### DIFF
--- a/inits/20-common.el
+++ b/inits/20-common.el
@@ -76,7 +76,7 @@
   (amx-mode))
 
 ;; to find project root
-(use-package find-file-in-project)
+(use-package projectile)
 
 ;; LSP (language server protocol) related packages
 ;; Install python-language-server[all] via pipx to make it work.


### PR DESCRIPTION
projectile works better with counsel-fzf. if counsel-fzf used within a project, projectile automatically detects the project root and use it as the search root path. find-file-in-project doesn't support this.