### PR TITLE
work-around pinentry on Ubuntu

### DIFF
--- a/inits/linux-common.el
+++ b/inits/linux-common.el
@@ -1,5 +1,17 @@
 ;; linux-common.el
 
+;; pinentry for Debian/Ubuntu without window system.
+;; pinentry shipped with Debian/Ubuntu disables --allow-emacs-pinentry compile option,
+;; so pinentry.el cannot be used. the follwoing script is much INSECURE, but anyway it works on CLI.
+;;
+;; https://github.com/ecraven/pinentry-emacs
+;;
+;; when window system available, use gtk version of pinentry.
+(unless (window-system)
+  (defun pinentry-emacs (desc prompt ok error)
+    (let ((str (read-passwd (concat (replace-regexp-in-string "%22" "\"" (replace-regexp-in-string "%0A" "\n" desc)) prompt ": "))))
+      str)))
+
 ;; font
 (when (window-system)
   (create-fontset-from-ascii-font "Ricty:pixelsize=18:weight=regular:slant=normal" nil "ricty")


### PR DESCRIPTION
UbuntuのCLI版pinentryがEmacsをサポートしていないので、セキュリティ的には問題のあるがとりあえず動く代替を導入

コメントにもあるが、この設定だけでは動かないので以下参考に設定してください

https://github.com/ecraven/pinentry-emacs

なおGUIが使えるならgtkのpinentryが問題なく動作するので、この代替は使う必要がない。macOSでもmacOS版のpinentryがあるはずなので問題ない。
