### PR TITLE
don't create lock files

### DIFF
--- a/inits/20-common.el
+++ b/inits/20-common.el
@@ -13,6 +13,9 @@
 ;; don't use tabs
 (setq-default indent-tabs-mode nil)
 
+;; don't create lock files
+(setq create-lockfiles nil)
+
 ;; apply theme and customize modeline color
 (when (window-system)
   ;; theme


### PR DESCRIPTION
ロックファイルは拡張子が元のファイルと同じなので、いろいろ不都合がある。

（例）create-react-appの開発サーバーが、ロックファイルを検知してコンパイルしようとする

あまりこういう機能を無効にはしたくないが、役に立った試しがないのも事実なのでとりあえず無効にする