### PR TITLE
add vterm

### DIFF
--- a/inits/linux-common.el
+++ b/inits/linux-common.el
@@ -20,3 +20,7 @@
 
 ;; use aspell for spell checking
 (setq ispell-program-name "aspell")
+
+(use-package vterm
+  :ensure t
+  :config (setq vterm-max-scrollback 10000))


### PR DESCRIPTION
Emacs上で動くターミナルエミュレータvtermを追加。

これまでターミナルにあまり決定打がなく、Screenで画面分割したりしていたが、EmacsとScreenの間でテキストをコピーしたり、ウィンドウを切り替えるのが手間だった。

vtermは依存ライブラリがあるが、動作が軽快でターミナルエミュレータに必要な機能を十分備えていて便利。

しばらくScreenでの画面分割をやめてこれにしようと思う（Screen自体はセッション管理が便利なので引き続き使う予定）。