### PR TITLE
fix: use python3 explicitly

### DIFF
--- a/inits/20-common.el
+++ b/inits/20-common.el
@@ -159,7 +159,10 @@
   :config
   (use-package visual-regexp-steroids
     :demand)
-  (setq vr/engine 'python))
+  (setq vr/engine 'python)
+  (setq
+   vr/command-python
+   (replace-regexp-in-string "^python " "python3 " vr/command-python)))
 (use-package which-key
   :diminish which-key-mode
   :hook (after-init . which-key-mode))


### PR DESCRIPTION
On Ubuntu systems `python` is not available, but `python3` does.